### PR TITLE
Freeze requirements.txt versions fixes #15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,23 +1,23 @@
 # Flask
-Flask
-Flask-Script
-Flask-Testing
-blinker
+Flask==0.12.4
+Flask-Script==2.0.6
+Flask-Testing==0.7.1
+blinker==1.4
 
 # Miscellaneous
-requests
-numpy
-pandas
-html5lib
+requests==2.19.1
+numpy==1.15.0
+pandas==0.23.3
+html5lib==1.0.1
 
 # Dev
-Fabric3
-coverage
+Fabric3==1.14.post1
+coverage==4.5.1
 
 # Production
-gunicorn
+gunicorn==19.9.0
 
 # Documentation
-Sphinx
-sphinx-autobuild
-sphinx-rtd-theme
+Sphinx==1.7.6
+sphinx-autobuild==0.7.1
+sphinx-rtd-theme==0.4.1


### PR DESCRIPTION
I've tested these versions using my [fork](https://github.com/niklas88/docker-completesearch) of the Dockerfile repository. The Completesearch UI launches and seems to work, I haven't tried building an image yet, though. 